### PR TITLE
Feature/fix imports and tests

### DIFF
--- a/BFWQuery.xcodeproj/project.pbxproj
+++ b/BFWQuery.xcodeproj/project.pbxproj
@@ -488,7 +488,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Submodules/fmdb/src",
@@ -506,7 +505,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Submodules/fmdb/src",
@@ -528,8 +526,6 @@
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "BFWQuery/BFWQuery-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 				HEADER_SEARCH_PATHS = (
@@ -553,8 +549,6 @@
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "BFWQuery/BFWQuery-Prefix.pch";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Submodules/fmdb/src",

--- a/BFWQuery.xcodeproj/project.pbxproj
+++ b/BFWQuery.xcodeproj/project.pbxproj
@@ -522,12 +522,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BFWQuery.app/BFWQuery";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
+					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Submodules/fmdb/src",
@@ -545,8 +543,8 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BFWQuery.app/BFWQuery";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
+					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				HEADER_SEARCH_PATHS = (

--- a/BFWQuery.xcodeproj/project.pbxproj
+++ b/BFWQuery.xcodeproj/project.pbxproj
@@ -489,6 +489,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Submodules/fmdb/src",
+				);
 				INFOPLIST_FILE = BFWQuery/Launch/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.barefeetware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -503,6 +507,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Submodules/fmdb/src",
+				);
 				INFOPLIST_FILE = BFWQuery/Launch/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.barefeetware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -524,7 +532,9 @@
 				GCC_PREFIX_HEADER = "BFWQuery/BFWQuery-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
+				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(SRCROOT)/Submodules/fmdb/src",
 				);
 				INFOPLIST_FILE = "BFWQueryTests/BFWQueryTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.barefeetware.${PRODUCT_NAME:rfc1034identifier}";
@@ -545,6 +555,10 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BFWQuery/BFWQuery-Prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Submodules/fmdb/src",
+				);
 				INFOPLIST_FILE = "BFWQueryTests/BFWQueryTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.barefeetware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/BFWQuery/Modules/BFWQuery/Model/BFWQuery.h
+++ b/BFWQuery/Modules/BFWQuery/Model/BFWQuery.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "FMDatabase.h"
+#import <FMDB/FMDatabase.h>
 
 @class FMResultSet;
 @class BFWQuery;


### PR DESCRIPTION
Fix invalid import syntax
- Current import will fail when built as dynamic framework

Add header search paths to fix compile errors  
Remove reference to precompiled header file  …
- It doesn't exist any more and causes compile errors

Reorganized and cleanup build settings
